### PR TITLE
feat: local whisper voice transcription for WeCom

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,14 @@ WECOM_CALLBACK_AES_KEY=
 
 # Optional: base path for webhook (default: /wecom/callback)
 WECOM_WEBHOOK_PATH=/wecom/callback
+
+# Optional: local voice transcription fallback (used when WeCom Recognition is empty)
+WECOM_VOICE_TRANSCRIBE_ENABLED=true
+WECOM_VOICE_TRANSCRIBE_PROVIDER=local-whisper-cli
+WECOM_VOICE_TRANSCRIBE_COMMAND=whisper-cli
+WECOM_VOICE_TRANSCRIBE_MODEL_PATH=/usr/local/opt/whisper-cpp/share/whisper-cpp/for-tests-ggml-tiny.bin
+WECOM_VOICE_TRANSCRIBE_MODEL=base
+WECOM_VOICE_TRANSCRIBE_TIMEOUT_MS=120000
+WECOM_VOICE_TRANSCRIBE_MAX_BYTES=10485760
+WECOM_VOICE_TRANSCRIBE_FFMPEG_ENABLED=true
+WECOM_VOICE_TRANSCRIBE_TRANSCODE_TO_WAV=true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3] - 2026-03-01
+
+### Added
+- 新增语音转写回退链路：当企业微信回调未提供 `Recognition` 时，插件会自动下载语音并调用本地 `whisper-cli/whisper`
+- 新增 AMR/非兼容格式自动转码：支持用 `ffmpeg` 转为 `wav` 后再转写
+- 新增本地转写配置项：`channels.wecom.voiceTranscription.*`（provider/command/modelPath 等）
+- 新增语音相关核心测试：配置解析与音频格式判断
+
+### Changed
+- `/status` 命令新增语音转写状态展示（模型、启用状态）
+- 语音失败时改为主动回包错误原因，避免“无响应”体感
+- 版本升级为 `0.4.3`
+
+### Fixed
+- 修复本地语音转写临时文件过早清理问题：避免 `whisper-cli` 偶发读取不到输入文件（code 2）
+
 ## [0.4.1] - 2026-02-28
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 ### 媒体功能
 - [x] 图片消息接收和 AI 识别（Vision 能力）
 - [x] 图片消息发送
-- [x] 语音消息转文字（需开启企业微信语音识别）
+- [x] 语音消息转文字（优先企业微信 Recognition，缺失时自动回退 STT）
 
 ### 用户体验
 - [x] 命令系统（/help、/status、/clear）
@@ -36,6 +36,8 @@
 - [OpenClaw](https://openclaw.ai) 已安装并配置
 - 企业微信管理员权限
 - 公网可访问的服务器（用于接收回调）
+- 本地语音识别命令（推荐 `whisper-cli`，可选 `whisper`）
+- （推荐）`ffmpeg`，用于 AMR 等不兼容格式自动转码后再转写
 
 ## 安装
 
@@ -71,6 +73,8 @@ npm install
   }
 }
 ```
+
+说明：示例里的 `for-tests-ggml-tiny.bin` 仅用于快速验证，线上建议换成更高质量模型（如 `ggml-base` / `ggml-small`）。
 
 ### 方式二：npm 安装（即将支持）
 
@@ -117,7 +121,19 @@ openclaw plugins install openclaw-wechat
       "agentId": 1000004,
       "callbackToken": "默认账户Token",
       "callbackAesKey": "默认账户EncodingAESKey",
-      "webhookPath": "/wecom/callback"
+      "webhookPath": "/wecom/callback",
+      "voiceTranscription": {
+        "enabled": true,
+        "provider": "local-whisper-cli",
+        "command": "whisper-cli",
+        "modelPath": "/usr/local/opt/whisper-cpp/share/whisper-cpp/for-tests-ggml-tiny.bin",
+        "model": "base",
+        "language": "zh",
+        "timeoutMs": 120000,
+        "maxBytes": 10485760,
+        "ffmpegEnabled": true,
+        "transcodeToWav": true
+      }
     }
   }
 }
@@ -261,7 +277,7 @@ npm run wecom:smoke
 |------|------|------|------|
 | 文本 | ✅ | ✅ | 完全支持，自动分段 |
 | 图片 | ✅ | ✅ | 支持 Vision 识别 |
-| 语音 | ✅ | ❌ | 需开启企业微信语音识别 |
+| 语音 | ✅ | ❌ | 优先用企业微信 Recognition；否则插件走 STT 回退 |
 | 视频 | ✅ | ❌ | 接收后保存临时文件供 AI 处理 |
 | 文件 | ✅ | ❌ | 接收后保存临时文件供 AI 处理 |
 | 链接 | ✅ | ❌ | 支持标题/描述/URL 提取 |
@@ -276,6 +292,15 @@ npm run wecom:smoke
 | `WECOM_CALLBACK_TOKEN` | 是 | 回调配置的 Token |
 | `WECOM_CALLBACK_AES_KEY` | 是 | 回调配置的 EncodingAESKey |
 | `WECOM_WEBHOOK_PATH` | 否 | Webhook 路径，默认 `/wecom/callback` |
+| `WECOM_VOICE_TRANSCRIBE_ENABLED` | 否 | 是否启用语音转写回退（默认 true） |
+| `WECOM_VOICE_TRANSCRIBE_PROVIDER` | 否 | 本地提供方：`local-whisper-cli` / `local-whisper` |
+| `WECOM_VOICE_TRANSCRIBE_COMMAND` | 否 | 本地命令路径（默认按 provider 自动探测） |
+| `WECOM_VOICE_TRANSCRIBE_MODEL_PATH` | 否 | `whisper-cli` 模型路径（推荐显式配置） |
+| `WECOM_VOICE_TRANSCRIBE_MODEL` | 否 | `whisper` 模型名（默认 `base`） |
+| `WECOM_VOICE_TRANSCRIBE_TIMEOUT_MS` | 否 | 转写超时毫秒数（默认 120000） |
+| `WECOM_VOICE_TRANSCRIBE_MAX_BYTES` | 否 | 最大允许转写音频大小（默认 10MB） |
+| `WECOM_VOICE_TRANSCRIBE_FFMPEG_ENABLED` | 否 | 不兼容音频格式时是否允许 ffmpeg 转码 |
+| `WECOM_VOICE_TRANSCRIBE_TRANSCODE_TO_WAV` | 否 | 是否优先转码为 wav 再识别（默认 true） |
 
 ## 故障排查
 

--- a/docs/channels/wecom.md
+++ b/docs/channels/wecom.md
@@ -12,6 +12,7 @@ This channel integrates OpenClaw with WeCom (企业微信) internal apps.
 - Inbound messages: text/image/voice/video/file/link
 - Outbound: text and image
 - Multi-account: supported (`channels.wecom.accounts`)
+- Voice recognition: WeCom `Recognition` first; local whisper fallback supported (`channels.wecom.voiceTranscription`)
 
 ## Callback URL
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,10 +1,14 @@
 {
   "id": "openclaw-wechat",
   "name": "OpenClaw-Wechat",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "description": "WeCom (企业微信) channel plugin for OpenClaw (自建应用回调 + 发送 API).",
-  "channels": ["wecom"],
-  "extensions": ["./src/index.js"],
+  "channels": [
+    "wecom"
+  ],
+  "extensions": [
+    "./src/index.js"
+  ],
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -27,8 +31,13 @@
       },
       "agentId": {
         "oneOf": [
-          { "type": "number" },
-          { "type": "string", "pattern": "^[0-9]+$" }
+          {
+            "type": "number"
+          },
+          {
+            "type": "string",
+            "pattern": "^[0-9]+$"
+          }
         ],
         "description": "企业微信 Agent ID"
       },
@@ -48,6 +57,88 @@
         "type": "string",
         "description": "Webhook 路径",
         "default": "/wecom/callback"
+      },
+      "voiceTranscription": {
+        "type": "object",
+        "description": "语音转写回退配置（当企业微信 Recognition 缺失时使用）",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "是否启用插件侧语音转写回退"
+          },
+          "provider": {
+            "type": "string",
+            "enum": [
+              "local-whisper-cli",
+              "local-whisper"
+            ],
+            "default": "local-whisper-cli",
+            "description": "本地转写提供方类型"
+          },
+          "command": {
+            "type": "string",
+            "description": "可选：本地转写命令（默认按 provider 自动探测）"
+          },
+          "apiBaseUrl": {
+            "type": "string",
+            "description": "已弃用：历史 OpenAI 转写配置，不再使用"
+          },
+          "apiKey": {
+            "type": "string",
+            "description": "已弃用：历史 OpenAI 转写配置，不再使用",
+            "x-sensitive": true
+          },
+          "apiKeyEnv": {
+            "type": "string",
+            "description": "已弃用：历史 OpenAI 转写配置，不再使用"
+          },
+          "modelPath": {
+            "type": "string",
+            "description": "local-whisper-cli 使用的本地模型文件路径（如 ggml/gguf）"
+          },
+          "model": {
+            "type": "string",
+            "default": "base",
+            "description": "local-whisper 使用的模型名（tiny/base/small/...）"
+          },
+          "language": {
+            "type": "string",
+            "description": "可选：转写语言（如 zh）"
+          },
+          "prompt": {
+            "type": "string",
+            "description": "可选：转写提示词"
+          },
+          "timeoutMs": {
+            "type": "integer",
+            "minimum": 1000,
+            "default": 20000,
+            "description": "转写请求超时时间（毫秒）"
+          },
+          "maxBytes": {
+            "type": "integer",
+            "minimum": 262144,
+            "default": 10485760,
+            "description": "允许转写的最大音频大小（字节）"
+          },
+          "ffmpegEnabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "当音频格式不兼容时，是否允许使用 ffmpeg 转码到 wav"
+          },
+          "transcodeToWav": {
+            "type": "boolean",
+            "default": true,
+            "description": "是否优先将语音统一转码为 wav 再交给本地模型"
+          },
+          "requireModelPath": {
+            "type": "boolean",
+            "default": true,
+            "description": "local-whisper-cli 模式下是否强制要求配置 modelPath"
+          }
+        }
       },
       "accounts": {
         "type": "object",
@@ -72,8 +163,13 @@
             },
             "agentId": {
               "oneOf": [
-                { "type": "number" },
-                { "type": "string", "pattern": "^[0-9]+$" }
+                {
+                  "type": "number"
+                },
+                {
+                  "type": "string",
+                  "pattern": "^[0-9]+$"
+                }
               ]
             },
             "callbackToken": {
@@ -91,15 +187,28 @@
               "default": "/wecom/callback"
             }
           },
-          "required": ["corpId", "corpSecret", "agentId"]
+          "required": [
+            "corpId",
+            "corpSecret",
+            "agentId"
+          ]
         }
       }
     }
   },
   "uiHints": {
-    "corpSecret": { "sensitive": true },
-    "callbackToken": { "sensitive": true },
-    "callbackAesKey": { "sensitive": true }
+    "corpSecret": {
+      "sensitive": true
+    },
+    "callbackToken": {
+      "sensitive": true
+    },
+    "callbackAesKey": {
+      "sensitive": true
+    },
+    "voiceTranscription.apiKey": {
+      "sensitive": true
+    }
   },
   "channel": {
     "id": "wecom",
@@ -109,6 +218,10 @@
     "docsLabel": "wecom",
     "blurb": "Enterprise WeChat internal app via callback + send API.",
     "order": 80,
-    "aliases": ["wework", "qiwei", "wxwork"]
+    "aliases": [
+      "wework",
+      "qiwei",
+      "wxwork"
+    ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-wechat",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-wechat",
-      "version": "0.4.1",
+      "version": "0.4.3",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.5"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-wechat",
-  "version": "0.4.1",
+  "version": "0.4.3",
   "private": true,
   "type": "module",
   "description": "WeCom (企业微信) channel plugin for OpenClaw (自建应用回调 + 发送 API).",

--- a/src/core.js
+++ b/src/core.js
@@ -2,6 +2,36 @@ import crypto from "node:crypto";
 
 export const WECOM_TEXT_BYTE_LIMIT = 2000;
 export const INBOUND_DEDUPE_TTL_MS = 5 * 60 * 1000;
+const FALSE_LIKE_VALUES = new Set(["0", "false", "off", "no"]);
+const TRUE_LIKE_VALUES = new Set(["1", "true", "on", "yes"]);
+const LOCAL_STT_DIRECT_SUPPORTED_CONTENT_TYPES = new Set([
+  "audio/flac",
+  "audio/m4a",
+  "audio/mp3",
+  "audio/mp4",
+  "audio/mpeg",
+  "audio/ogg",
+  "audio/wav",
+  "audio/webm",
+  "audio/x-m4a",
+  "audio/x-wav",
+  "audio/x-flac",
+]);
+const AUDIO_CONTENT_TYPE_TO_EXTENSION = Object.freeze({
+  "audio/amr": ".amr",
+  "audio/flac": ".flac",
+  "audio/m4a": ".m4a",
+  "audio/mp3": ".mp3",
+  "audio/mp4": ".m4a",
+  "audio/mpeg": ".mp3",
+  "audio/ogg": ".ogg",
+  "audio/silk": ".sil",
+  "audio/wav": ".wav",
+  "audio/webm": ".webm",
+  "audio/x-m4a": ".m4a",
+  "audio/x-wav": ".wav",
+  "audio/x-flac": ".flac",
+});
 
 const inboundMessageDedupe = new Map();
 
@@ -122,4 +152,151 @@ export function pickAccountBySignature({ accounts, msgSignature, timestamp, nonc
     if (expected === msgSignature) return account;
   }
   return null;
+}
+
+function pickFirstNonEmptyString(...values) {
+  for (const value of values) {
+    if (typeof value !== "string") continue;
+    const trimmed = value.trim();
+    if (trimmed) return trimmed;
+  }
+  return "";
+}
+
+function asPositiveInteger(value, fallback) {
+  const n = Number(value);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.floor(n);
+}
+
+function parseBooleanLike(value, fallback) {
+  if (typeof value === "boolean") return value;
+  if (typeof value !== "string") return fallback;
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) return fallback;
+  if (TRUE_LIKE_VALUES.has(normalized)) return true;
+  if (FALSE_LIKE_VALUES.has(normalized)) return false;
+  return fallback;
+}
+
+function readVoiceEnv(envVars, processEnv, suffix) {
+  const keys = [`WECOM_VOICE_TRANSCRIBE_${suffix}`, `WECOM_VOICE_${suffix}`];
+  for (const key of keys) {
+    const fromConfig = envVars?.[key];
+    if (fromConfig != null && String(fromConfig).trim() !== "") return fromConfig;
+    const fromProcess = processEnv?.[key];
+    if (fromProcess != null && String(fromProcess).trim() !== "") return fromProcess;
+  }
+  return undefined;
+}
+
+export function normalizeAudioContentType(contentType) {
+  const normalized = String(contentType ?? "")
+    .trim()
+    .toLowerCase()
+    .split(";")[0]
+    .trim();
+  return normalized || "";
+}
+
+export function isLocalVoiceInputTypeDirectlySupported(contentType) {
+  const normalized = normalizeAudioContentType(contentType);
+  if (!normalized) return false;
+  return LOCAL_STT_DIRECT_SUPPORTED_CONTENT_TYPES.has(normalized);
+}
+
+export function pickAudioFileExtension({ contentType, fileName } = {}) {
+  const normalized = normalizeAudioContentType(contentType);
+  if (normalized && AUDIO_CONTENT_TYPE_TO_EXTENSION[normalized]) {
+    return AUDIO_CONTENT_TYPE_TO_EXTENSION[normalized];
+  }
+  const extMatch = String(fileName ?? "")
+    .trim()
+    .toLowerCase()
+    .match(/\.([a-z0-9]{1,8})$/);
+  if (extMatch) return `.${extMatch[1]}`;
+  return ".bin";
+}
+
+export function resolveVoiceTranscriptionConfig({ channelConfig, envVars = {}, processEnv = process.env } = {}) {
+  const voiceConfig =
+    channelConfig?.voiceTranscription && typeof channelConfig.voiceTranscription === "object"
+      ? channelConfig.voiceTranscription
+      : {};
+
+  const enabled = parseBooleanLike(
+    voiceConfig.enabled,
+    parseBooleanLike(readVoiceEnv(envVars, processEnv, "ENABLED"), true),
+  );
+  const providerRaw = pickFirstNonEmptyString(
+    voiceConfig.provider,
+    readVoiceEnv(envVars, processEnv, "PROVIDER"),
+    "local-whisper-cli",
+  );
+  const provider = providerRaw.toLowerCase();
+  const command = pickFirstNonEmptyString(
+    voiceConfig.command,
+    readVoiceEnv(envVars, processEnv, "COMMAND"),
+  );
+  const homebrewPrefix = pickFirstNonEmptyString(processEnv?.HOMEBREW_PREFIX);
+  const defaultHomebrewModelPath = homebrewPrefix
+    ? `${homebrewPrefix}/opt/whisper-cpp/share/whisper-cpp/for-tests-ggml-tiny.bin`
+    : "";
+  const modelPath = pickFirstNonEmptyString(
+    voiceConfig.modelPath,
+    readVoiceEnv(envVars, processEnv, "MODEL_PATH"),
+    processEnv?.WHISPER_MODEL,
+    processEnv?.WHISPER_MODEL_PATH,
+    defaultHomebrewModelPath,
+    "/usr/local/opt/whisper-cpp/share/whisper-cpp/for-tests-ggml-tiny.bin",
+    "/opt/homebrew/opt/whisper-cpp/share/whisper-cpp/for-tests-ggml-tiny.bin",
+  );
+  const model = pickFirstNonEmptyString(
+    voiceConfig.model,
+    readVoiceEnv(envVars, processEnv, "MODEL"),
+    "base",
+  );
+  const language = pickFirstNonEmptyString(
+    voiceConfig.language,
+    readVoiceEnv(envVars, processEnv, "LANGUAGE"),
+  );
+  const prompt = pickFirstNonEmptyString(
+    voiceConfig.prompt,
+    readVoiceEnv(envVars, processEnv, "PROMPT"),
+  );
+  const timeoutMs = asPositiveInteger(
+    voiceConfig.timeoutMs,
+    asPositiveInteger(readVoiceEnv(envVars, processEnv, "TIMEOUT_MS"), 120000),
+  );
+  const maxBytes = asPositiveInteger(
+    voiceConfig.maxBytes,
+    asPositiveInteger(readVoiceEnv(envVars, processEnv, "MAX_BYTES"), 10 * 1024 * 1024),
+  );
+  const ffmpegEnabled = parseBooleanLike(
+    voiceConfig.ffmpegEnabled,
+    parseBooleanLike(readVoiceEnv(envVars, processEnv, "FFMPEG_ENABLED"), true),
+  );
+  const transcodeToWav = parseBooleanLike(
+    voiceConfig.transcodeToWav,
+    parseBooleanLike(readVoiceEnv(envVars, processEnv, "TRANSCODE_TO_WAV"), true),
+  );
+  const requireModelPath = parseBooleanLike(
+    voiceConfig.requireModelPath,
+    parseBooleanLike(readVoiceEnv(envVars, processEnv, "REQUIRE_MODEL_PATH"), true),
+  );
+
+  return {
+    enabled,
+    provider,
+    command: command || undefined,
+    modelPath: modelPath || undefined,
+    model,
+    language: language || undefined,
+    prompt: prompt || undefined,
+    timeoutMs,
+    maxBytes,
+    ffmpegEnabled,
+    transcodeToWav,
+    requireModelPath,
+  };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,10 @@
 import crypto from "node:crypto";
 import { XMLParser } from "fast-xml-parser";
 import { normalizePluginHttpPath } from "openclaw/plugin-sdk";
-import { writeFile, unlink, mkdir } from "node:fs/promises";
+import { writeFile, unlink, mkdir, readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, extname, join } from "node:path";
+import { spawn } from "node:child_process";
 import {
   WECOM_TEXT_BYTE_LIMIT,
   buildWecomSessionId,
@@ -12,6 +13,10 @@ import {
   resetInboundMessageDedupeForTests,
   computeMsgSignature,
   getByteLength,
+  isLocalVoiceInputTypeDirectlySupported,
+  normalizeAudioContentType,
+  pickAudioFileExtension,
+  resolveVoiceTranscriptionConfig,
   splitWecomText,
   pickAccountBySignature,
 } from "./core.js";
@@ -23,9 +28,14 @@ const xmlParser = new XMLParser({
 
 // 请求体大小限制 (1MB)
 const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
-const PLUGIN_VERSION = "0.4.1";
+const PLUGIN_VERSION = "0.4.3";
 const WECOM_TEMP_DIR_NAME = "openclaw-wechat";
 const WECOM_TEMP_FILE_RETENTION_MS = 30 * 60 * 1000;
+const FFMPEG_PATH_CHECK_CACHE = {
+  checked: false,
+  available: false,
+};
+const COMMAND_PATH_CHECK_CACHE = new Map();
 
 function readRequestBody(req, maxSize = MAX_REQUEST_BODY_SIZE) {
   return new Promise((resolve, reject) => {
@@ -262,6 +272,343 @@ async function fetchWithRetry(url, options = {}, maxRetries = 3, initialDelay = 
     }
   }
   throw lastError || new Error(`Fetch failed after ${maxRetries} retries`);
+}
+
+function runProcessWithTimeout({ command, args, timeoutMs = 15000, allowNonZeroExitCode = false }) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer =
+      timeoutMs > 0
+        ? setTimeout(() => {
+            timedOut = true;
+            child.kill("SIGKILL");
+          }, timeoutMs)
+        : null;
+
+    child.stdout.on("data", (chunk) => {
+      stdout += String(chunk);
+      if (stdout.length > 4000) stdout = stdout.slice(-4000);
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += String(chunk);
+      if (stderr.length > 4000) stderr = stderr.slice(-4000);
+    });
+    child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code) => {
+      if (timer) clearTimeout(timer);
+      if (timedOut) {
+        reject(new Error(`${command} timed out after ${timeoutMs}ms`));
+        return;
+      }
+      if (code !== 0 && !allowNonZeroExitCode) {
+        reject(new Error(`${command} exited with code ${code}: ${stderr.trim().slice(0, 500)}`));
+        return;
+      }
+      resolve({ stdout: stdout.trim(), stderr: stderr.trim() });
+    });
+  });
+}
+
+async function checkCommandAvailable(command) {
+  const normalized = String(command ?? "").trim();
+  if (!normalized) return false;
+  if (COMMAND_PATH_CHECK_CACHE.has(normalized)) {
+    return COMMAND_PATH_CHECK_CACHE.get(normalized);
+  }
+  try {
+    await runProcessWithTimeout({
+      command: normalized,
+      args: ["--help"],
+      timeoutMs: 4000,
+      allowNonZeroExitCode: true,
+    });
+    COMMAND_PATH_CHECK_CACHE.set(normalized, true);
+    return true;
+  } catch (err) {
+    COMMAND_PATH_CHECK_CACHE.set(normalized, false);
+    return false;
+  }
+}
+
+async function ensureFfmpegAvailable(logger) {
+  if (FFMPEG_PATH_CHECK_CACHE.checked) return FFMPEG_PATH_CHECK_CACHE.available;
+  const available = await checkCommandAvailable("ffmpeg");
+  FFMPEG_PATH_CHECK_CACHE.checked = true;
+  FFMPEG_PATH_CHECK_CACHE.available = available;
+  if (!available) {
+    logger?.warn?.("wecom: ffmpeg not available");
+  }
+  return available;
+}
+
+async function resolveLocalWhisperCommand({ voiceConfig, logger }) {
+  const provider = String(voiceConfig.provider ?? "").trim().toLowerCase();
+  const explicitCommand = String(voiceConfig.command ?? "").trim();
+  const fallbackCandidates =
+    provider === "local-whisper"
+      ? ["whisper"]
+      : provider === "local-whisper-cli"
+        ? ["whisper-cli"]
+        : [];
+  const candidates = explicitCommand ? [explicitCommand, ...fallbackCandidates] : fallbackCandidates;
+
+  if (candidates.length === 0) {
+    throw new Error(
+      `unsupported voice transcription provider: ${provider || "unknown"} (supported: local-whisper-cli/local-whisper)`,
+    );
+  }
+
+  for (const cmd of candidates) {
+    if (await checkCommandAvailable(cmd)) {
+      if (explicitCommand && cmd !== explicitCommand) {
+        logger?.warn?.(`wecom: voice command ${explicitCommand} unavailable, fallback to ${cmd}`);
+      }
+      return cmd;
+    }
+  }
+
+  throw new Error(`local transcription command not found: ${candidates.join(" / ")}`);
+}
+
+function resolveWecomVoiceTranscriptionConfig(api) {
+  const cfg = api?.config ?? {};
+  return resolveVoiceTranscriptionConfig({
+    channelConfig: cfg?.channels?.wecom,
+    envVars: cfg?.env?.vars ?? {},
+    processEnv: process.env,
+  });
+}
+
+async function transcodeAudioToWav({
+  buffer,
+  inputContentType,
+  inputFileName,
+  logger,
+  timeoutMs = 30000,
+}) {
+  const tempDir = join(tmpdir(), WECOM_TEMP_DIR_NAME);
+  await mkdir(tempDir, { recursive: true });
+  const nonce = `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const inputExt = pickAudioFileExtension({ contentType: inputContentType, fileName: inputFileName });
+  const inputPath = join(tempDir, `voice-input-${nonce}${inputExt || ".bin"}`);
+  const outputPath = join(tempDir, `voice-output-${nonce}.wav`);
+
+  try {
+    await writeFile(inputPath, buffer);
+    await runProcessWithTimeout({
+      command: "ffmpeg",
+      args: [
+        "-y",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-i",
+        inputPath,
+        "-ac",
+        "1",
+        "-ar",
+        "16000",
+        "-f",
+        "wav",
+        outputPath,
+      ],
+      timeoutMs,
+    });
+    const outputBuffer = await readFile(outputPath);
+    logger?.info?.(`wecom: transcoded voice to wav size=${outputBuffer.length} bytes`);
+    return {
+      buffer: outputBuffer,
+      contentType: "audio/wav",
+      fileName: `voice-${Date.now()}.wav`,
+    };
+  } finally {
+    await Promise.allSettled([unlink(inputPath), unlink(outputPath)]);
+  }
+}
+
+async function transcribeWithWhisperCli({
+  command,
+  modelPath,
+  audioPath,
+  language,
+  prompt,
+  timeoutMs,
+}) {
+  if (!modelPath) {
+    throw new Error("local-whisper-cli requires voiceTranscription.modelPath");
+  }
+
+  const tempDir = join(tmpdir(), WECOM_TEMP_DIR_NAME);
+  await mkdir(tempDir, { recursive: true });
+  const outputBase = join(tempDir, `voice-whisper-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  const outputTxt = `${outputBase}.txt`;
+
+  const args = ["-m", modelPath, "-f", audioPath, "-otxt", "-of", outputBase, "--no-prints"];
+  if (language) args.push("-l", language);
+  if (prompt) args.push("--prompt", prompt);
+
+  try {
+    await runProcessWithTimeout({
+      command,
+      args,
+      timeoutMs,
+    });
+    const transcript = String(await readFile(outputTxt, "utf8")).trim();
+    if (!transcript) {
+      throw new Error("whisper-cli transcription output is empty");
+    }
+    return transcript;
+  } finally {
+    await Promise.allSettled([unlink(outputTxt)]);
+  }
+}
+
+async function transcribeWithWhisperPython({
+  command,
+  model,
+  audioPath,
+  language,
+  prompt,
+  timeoutMs,
+}) {
+  const tempDir = join(tmpdir(), WECOM_TEMP_DIR_NAME);
+  await mkdir(tempDir, { recursive: true });
+  const audioBaseName = basename(audioPath, extname(audioPath));
+  const outputTxt = join(tempDir, `${audioBaseName}.txt`);
+
+  const args = [
+    audioPath,
+    "--model",
+    model || "base",
+    "--output_format",
+    "txt",
+    "--output_dir",
+    tempDir,
+    "--task",
+    "transcribe",
+  ];
+  if (language) args.push("--language", language);
+  if (prompt) args.push("--initial_prompt", prompt);
+
+  try {
+    await runProcessWithTimeout({
+      command,
+      args,
+      timeoutMs,
+    });
+    const transcript = String(await readFile(outputTxt, "utf8")).trim();
+    if (!transcript) {
+      throw new Error("whisper transcription output is empty");
+    }
+    return transcript;
+  } finally {
+    await Promise.allSettled([unlink(outputTxt)]);
+  }
+}
+
+async function transcribeInboundVoice({
+  api,
+  buffer,
+  contentType,
+  mediaId,
+  voiceConfig,
+}) {
+  if (!voiceConfig.enabled) {
+    throw new Error("voice transcription is disabled");
+  }
+
+  let audioBuffer = buffer;
+  let normalizedContentType = normalizeAudioContentType(contentType) || "application/octet-stream";
+  let fileName = `voice-${mediaId}${pickAudioFileExtension({
+    contentType: normalizedContentType,
+    fileName: `voice-${mediaId}`,
+  })}`;
+
+  if (audioBuffer.length > voiceConfig.maxBytes) {
+    throw new Error(`audio size ${audioBuffer.length} exceeds maxBytes ${voiceConfig.maxBytes}`);
+  }
+
+  const isWav = normalizedContentType === "audio/wav" || normalizedContentType === "audio/x-wav";
+  const unsupportedDirect = !isLocalVoiceInputTypeDirectlySupported(normalizedContentType);
+  const shouldTranscode = unsupportedDirect || (voiceConfig.transcodeToWav === true && !isWav);
+  if (shouldTranscode) {
+    if (!voiceConfig.ffmpegEnabled) {
+      throw new Error(
+        `content type ${normalizedContentType || "unknown"} requires ffmpeg conversion but ffmpegEnabled=false`,
+      );
+    }
+    const ffmpegAvailable = await ensureFfmpegAvailable(api.logger);
+    if (!ffmpegAvailable) {
+      throw new Error(
+        `unsupported content type ${normalizedContentType || "unknown"} and ffmpeg not available`,
+      );
+    }
+    const transcoded = await transcodeAudioToWav({
+      buffer: audioBuffer,
+      inputContentType: normalizedContentType,
+      inputFileName: fileName,
+      logger: api.logger,
+      timeoutMs: Math.max(10000, Math.min(voiceConfig.timeoutMs, 45000)),
+    });
+    audioBuffer = transcoded.buffer;
+    normalizedContentType = transcoded.contentType;
+    fileName = transcoded.fileName;
+  }
+
+  const command = await resolveLocalWhisperCommand({ voiceConfig, logger: api.logger });
+  const provider = String(voiceConfig.provider ?? "").trim().toLowerCase();
+
+  const tempDir = join(tmpdir(), WECOM_TEMP_DIR_NAME);
+  await mkdir(tempDir, { recursive: true });
+  const audioPath = join(
+    tempDir,
+    `voice-transcribe-${Date.now()}-${Math.random().toString(36).slice(2)}${pickAudioFileExtension({
+      contentType: normalizedContentType,
+      fileName,
+    })}`,
+  );
+
+  await writeFile(audioPath, audioBuffer);
+  try {
+    if (provider === "local-whisper-cli") {
+      if (voiceConfig.requireModelPath !== false && !voiceConfig.modelPath) {
+        throw new Error(
+          "voiceTranscription.modelPath is required for local-whisper-cli (or set requireModelPath=false)",
+        );
+      }
+      const transcript = await transcribeWithWhisperCli({
+        command,
+        modelPath: voiceConfig.modelPath,
+        audioPath,
+        language: voiceConfig.language,
+        prompt: voiceConfig.prompt,
+        timeoutMs: voiceConfig.timeoutMs,
+      });
+      return transcript;
+    }
+
+    if (provider === "local-whisper") {
+      const transcript = await transcribeWithWhisperPython({
+        command,
+        model: voiceConfig.model,
+        audioPath,
+        language: voiceConfig.language,
+        prompt: voiceConfig.prompt,
+        timeoutMs: voiceConfig.timeoutMs,
+      });
+      return transcript;
+    }
+
+    throw new Error(`unsupported local provider ${provider}`);
+  } finally {
+    await Promise.allSettled([unlink(audioPath)]);
+  }
 }
 
 // 简单的限流器，防止触发企业微信 API 限流
@@ -1013,6 +1360,10 @@ async function handleHelpCommand({ api, fromUser, corpId, corpSecret, agentId })
 async function handleStatusCommand({ api, fromUser, corpId, corpSecret, agentId, accountId }) {
   const config = getWecomConfig(api, accountId);
   const accountIds = listWecomAccountIds(api);
+  const voiceConfig = resolveWecomVoiceTranscriptionConfig(api);
+  const voiceStatusLine = voiceConfig.enabled
+    ? `✅ 语音消息转写（本地 ${voiceConfig.provider}，模型: ${voiceConfig.modelPath || voiceConfig.model}）`
+    : "⚠️ 语音消息转写回退未启用（仅使用企业微信 Recognition）";
 
   const statusText = `📊 系统状态
 
@@ -1029,7 +1380,8 @@ async function handleStatusCommand({ api, fromUser, corpId, corpSecret, agentId,
 ✅ 命令系统
 ✅ Markdown 转换
 ✅ API 限流
-✅ 多账户支持`;
+✅ 多账户支持
+${voiceStatusLine}`;
 
   await sendWecomText({ corpId, corpSecret, agentId, toUser: fromUser, text: statusText });
   return true;
@@ -1145,14 +1497,53 @@ async function processInboundMessage({
     // 处理语音消息
     if (msgType === "voice" && mediaId) {
       api.logger.info?.(`wecom: received voice message mediaId=${mediaId}`);
-
-      // 企业微信开启语音识别后，Recognition 字段会包含转写结果
-      if (recognition) {
-        api.logger.info?.(`wecom: voice recognition result: ${recognition.slice(0, 50)}...`);
-        messageText = `[语音消息] ${recognition}`;
+      const recognizedText = String(recognition ?? "").trim();
+      if (recognizedText) {
+        api.logger.info?.(`wecom: voice recognition result from WeCom: ${recognizedText.slice(0, 50)}...`);
+        messageText = `[语音消息转写]\n${recognizedText}`;
       } else {
-        // 没有开启语音识别，提示用户
-        messageText = "[用户发送了一条语音消息]\n\n请告诉用户目前暂不支持语音消息，建议发送文字消息。";
+        const voiceConfig = resolveWecomVoiceTranscriptionConfig(api);
+        if (!voiceConfig.enabled) {
+          api.logger.info?.("wecom: voice transcription fallback disabled; asking user to send text");
+          await sendWecomText({
+            corpId,
+            corpSecret,
+            agentId,
+            toUser: fromUser,
+            text: "语音识别未启用，请先开启企业微信语音识别，或直接发送文字消息。",
+            logger: api.logger,
+          });
+          return;
+        }
+
+        try {
+          const { buffer, contentType } = await downloadWecomMedia({ corpId, corpSecret, mediaId });
+          api.logger.info?.(
+            `wecom: downloaded voice media for transcription, size=${buffer.length}, type=${contentType || "unknown"}`,
+          );
+          const transcript = await transcribeInboundVoice({
+            api,
+            buffer,
+            contentType,
+            mediaId,
+            voiceConfig,
+          });
+          messageText = `[语音消息转写]\n${transcript}`;
+          api.logger.info?.(`wecom: voice transcribed via ${voiceConfig.model}: ${transcript.slice(0, 80)}...`);
+        } catch (voiceErr) {
+          api.logger.warn?.(`wecom: voice transcription failed: ${String(voiceErr?.message || voiceErr)}`);
+          await sendWecomText({
+            corpId,
+            corpSecret,
+            agentId,
+            toUser: fromUser,
+            text:
+              "语音识别失败，请稍后重试。\n" +
+              "如持续失败，请确认本地 whisper 命令可用、模型路径已配置，并已安装 ffmpeg。",
+            logger: api.logger,
+          });
+          return;
+        }
       }
     }
 

--- a/tests/wecom-core.test.mjs
+++ b/tests/wecom-core.test.mjs
@@ -55,3 +55,66 @@ test("pickAccountBySignature selects account by token", () => {
   });
   assert.equal(matched?.accountId, "b");
 });
+
+test("resolveVoiceTranscriptionConfig uses defaults", () => {
+  const voice = core.resolveVoiceTranscriptionConfig({
+    channelConfig: {},
+    envVars: {},
+    processEnv: {},
+  });
+  assert.equal(voice.enabled, true);
+  assert.equal(voice.provider, "local-whisper-cli");
+  assert.equal(voice.model, "base");
+  assert.equal(voice.timeoutMs, 120000);
+  assert.equal(voice.maxBytes, 10 * 1024 * 1024);
+});
+
+test("resolveVoiceTranscriptionConfig reads command/model settings", () => {
+  const fromConfig = core.resolveVoiceTranscriptionConfig({
+    channelConfig: {
+      voiceTranscription: {
+        provider: "local-whisper",
+        command: "whisper",
+        model: "large-v3",
+        modelPath: "/models/ggml-base.bin",
+      },
+    },
+    envVars: {},
+    processEnv: {},
+  });
+  assert.equal(fromConfig.provider, "local-whisper");
+  assert.equal(fromConfig.command, "whisper");
+  assert.equal(fromConfig.model, "large-v3");
+  assert.equal(fromConfig.modelPath, "/models/ggml-base.bin");
+
+  const fromEnv = core.resolveVoiceTranscriptionConfig({
+    channelConfig: {
+      voiceTranscription: {
+        provider: "local-whisper-cli",
+      },
+    },
+    envVars: {
+      WECOM_VOICE_TRANSCRIBE_MODEL_PATH: "/models/env.ggml",
+      WECOM_VOICE_TRANSCRIBE_COMMAND: "whisper-cli",
+    },
+    processEnv: {
+      WHISPER_MODEL_PATH: "/models/fallback.ggml",
+    },
+  });
+  assert.equal(fromEnv.command, "whisper-cli");
+  assert.equal(fromEnv.modelPath, "/models/env.ggml");
+});
+
+test("audio content type support helpers work for stt", () => {
+  assert.equal(core.isLocalVoiceInputTypeDirectlySupported("audio/wav"), true);
+  assert.equal(core.isLocalVoiceInputTypeDirectlySupported("audio/amr"), false);
+  assert.equal(core.normalizeAudioContentType(" audio/mpeg; charset=utf-8 "), "audio/mpeg");
+  assert.equal(
+    core.pickAudioFileExtension({ contentType: "audio/mpeg" }),
+    ".mp3",
+  );
+  assert.equal(
+    core.pickAudioFileExtension({ fileName: "voice.amr" }),
+    ".amr",
+  );
+});


### PR DESCRIPTION
## Summary
- migrate WeCom voice transcription fallback from OpenAI-compatible API to local `whisper-cli` / `whisper`
- keep `ffmpeg` transcoding path for unsupported input formats (AMR etc.)
- add local provider config fields: `provider`, `command`, `modelPath`, `transcodeToWav`, `requireModelPath`
- update README/schema/.env example and bump plugin to `0.4.3`
- fix temp audio cleanup race that caused `whisper-cli` exit code 2

## Verification
- `npm test` passed (syntax + unit tests)
- local `whisper-cli` command validated with local `ggml-base.bin`
- gateway restarted and WeCom channel remained healthy

## Notes
- keeps backward-compatible schema keys (`apiKey`, `apiKeyEnv`, `apiBaseUrl`) as deprecated placeholders to avoid config validation breaks
