### PR TITLE
feat: 迁移 WeCom 指令白名单、群聊触发与文本防抖策略

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,18 @@ WECOM_WEBHOOK_PATH=/wecom/callback
 # Optional: outbound proxy for WeCom API (gettoken/message/send/media/get...)
 WECOM_PROXY=
 
+# Optional: command and group policy
+WECOM_ADMIN_USERS=
+WECOM_COMMANDS_ENABLED=false
+WECOM_COMMANDS_ALLOWLIST=/help,/status,/clear,/reset,/new,/compact
+WECOM_COMMANDS_REJECT_MESSAGE=该指令未开放，请联系管理员。
+WECOM_GROUP_CHAT_ENABLED=true
+WECOM_GROUP_CHAT_REQUIRE_MENTION=false
+WECOM_GROUP_CHAT_MENTION_PATTERNS=@
+WECOM_DEBOUNCE_ENABLED=false
+WECOM_DEBOUNCE_WINDOW_MS=1200
+WECOM_DEBOUNCE_MAX_BATCH=6
+
 # Optional: local voice transcription fallback (used when WeCom Recognition is empty)
 WECOM_VOICE_TRANSCRIBE_ENABLED=true
 WECOM_VOICE_TRANSCRIBE_PROVIDER=local-whisper-cli

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.5] - 2026-03-01
+
+### Added
+- 新增命令白名单策略：`channels.wecom.commands.*` 与 `WECOM_COMMANDS_*`
+- 新增管理员绕过配置：`channels.wecom.adminUsers` 与 `WECOM_ADMIN_USERS`
+- 新增群聊触发策略：`channels.wecom.groupChat.*` 与 `WECOM_GROUP_CHAT_*`
+- 新增文本防抖合并：`channels.wecom.debounce.*` 与 `WECOM_DEBOUNCE_*`
+- 新增核心测试覆盖命令解析、策略配置和防抖配置边界
+
+### Changed
+- 文本入站链路接入防抖调度；命令消息优先直通，自动冲刷队列
+- `/status` 增加命令白名单、群聊触发、防抖状态展示
+- 版本升级为 `0.4.5`
+
+### Fixed
+- 修复新策略已实现但未接入主处理链路的问题（文本仍走旧路径）
+- 修复群聊场景下命令判定偏差（支持先去除 mention 再识别 `/` 指令）
+
 ## [0.4.4] - 2026-03-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@
 - [x] 语音消息转文字（优先企业微信 Recognition，缺失时自动回退 STT）
 
 ### 用户体验
-- [x] 命令系统（/help、/status、/clear）
+- [x] 命令系统（/help、/status、/clear）+ 指令白名单/管理员绕过
 - [x] Markdown 格式自动转换
 - [x] 长消息自动分段（2048 字符限制）
+- [x] 文本防抖合并（短时间多条消息自动合并）
 - [x] API 限流保护
 
 ### 高级功能
 - [x] 多账户支持
-- [x] 群聊支持
+- [x] 群聊支持（可配置仅 @ 时触发）
 - [x] Token 并发安全
 - [x] wecom:selfcheck 一键自检
 - [x] WeCom API 出站代理（`WECOM_PROXY` / `channels.wecom.outboundProxy`）
@@ -125,6 +126,33 @@ openclaw plugins install openclaw-wechat
       "callbackAesKey": "默认账户EncodingAESKey",
       "webhookPath": "/wecom/callback",
       "outboundProxy": "http://127.0.0.1:7890",
+      "adminUsers": [
+        "dingxiang"
+      ],
+      "commands": {
+        "enabled": true,
+        "allowlist": [
+          "/help",
+          "/status",
+          "/reset",
+          "/new",
+          "/compact"
+        ],
+        "rejectMessage": "该指令未开放，请联系管理员。"
+      },
+      "groupChat": {
+        "enabled": true,
+        "requireMention": true,
+        "mentionPatterns": [
+          "@",
+          "@机器人"
+        ]
+      },
+      "debounce": {
+        "enabled": true,
+        "windowMs": 1200,
+        "maxBatch": 6
+      },
       "voiceTranscription": {
         "enabled": true,
         "provider": "local-whisper-cli",
@@ -276,6 +304,22 @@ npm run wecom:smoke
 | `/status` | 查看系统状态（含账户信息） |
 | `/clear` | 重置会话（等价于 `/reset`） |
 
+可选策略（默认关闭，保持兼容）：
+- `channels.wecom.commands.enabled=true` 后，仅允许 `allowlist` 中的 `/` 指令
+- `channels.wecom.adminUsers` 可配置管理员用户 ID，绕过白名单限制
+
+### 群聊触发策略
+
+- `channels.wecom.groupChat.enabled`：是否处理群聊消息（默认 `true`）
+- `channels.wecom.groupChat.requireMention`：是否要求命中 `@` 才触发（默认 `false`）
+- `channels.wecom.groupChat.mentionPatterns`：提及匹配关键字列表（默认 `["@"]`）
+
+### 文本防抖合并
+
+- `channels.wecom.debounce.enabled`：启用后在窗口期内合并多条文本再投递给模型
+- `channels.wecom.debounce.windowMs`：防抖窗口（默认 `1200`，范围 `100-10000`）
+- `channels.wecom.debounce.maxBatch`：单批最大合并条数（默认 `6`，范围 `1-50`）
+
 ### 支持的消息类型
 
 | 类型 | 接收 | 发送 | 说明 |
@@ -299,6 +343,16 @@ npm run wecom:smoke
 | `WECOM_WEBHOOK_PATH` | 否 | Webhook 路径，默认 `/wecom/callback` |
 | `WECOM_PROXY` | 否 | WeCom API 出站代理 URL（如 `http://127.0.0.1:7890`） |
 | `WECOM_<ACCOUNT>_PROXY` | 否 | 指定账户专用代理（优先级高于 `WECOM_PROXY`） |
+| `WECOM_ADMIN_USERS` | 否 | 管理员用户 ID 列表（逗号分隔），可绕过命令白名单 |
+| `WECOM_COMMANDS_ENABLED` | 否 | 是否启用命令白名单（默认 false） |
+| `WECOM_COMMANDS_ALLOWLIST` | 否 | 允许的命令列表（逗号分隔） |
+| `WECOM_COMMANDS_REJECT_MESSAGE` | 否 | 未授权命令时回复文案 |
+| `WECOM_GROUP_CHAT_ENABLED` | 否 | 是否启用群聊消息处理（默认 true） |
+| `WECOM_GROUP_CHAT_REQUIRE_MENTION` | 否 | 群聊是否要求 mention 才触发（默认 false） |
+| `WECOM_GROUP_CHAT_MENTION_PATTERNS` | 否 | mention 关键字列表（逗号分隔） |
+| `WECOM_DEBOUNCE_ENABLED` | 否 | 是否启用文本防抖合并（默认 false） |
+| `WECOM_DEBOUNCE_WINDOW_MS` | 否 | 防抖窗口毫秒（默认 1200） |
+| `WECOM_DEBOUNCE_MAX_BATCH` | 否 | 单次最多合并条数（默认 6） |
 | `WECOM_VOICE_TRANSCRIBE_ENABLED` | 否 | 是否启用语音转写回退（默认 true） |
 | `WECOM_VOICE_TRANSCRIBE_PROVIDER` | 否 | 本地提供方：`local-whisper-cli` / `local-whisper` |
 | `WECOM_VOICE_TRANSCRIBE_COMMAND` | 否 | 本地命令路径（默认按 provider 自动探测） |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "openclaw-wechat",
   "name": "OpenClaw-Wechat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "WeCom (企业微信) channel plugin for OpenClaw (自建应用回调 + 发送 API).",
   "channels": [
     "wecom"
@@ -61,6 +61,89 @@
       "outboundProxy": {
         "type": "string",
         "description": "可选：WeCom 出站 API 代理（如 http://127.0.0.1:7890）"
+      },
+      "adminUsers": {
+        "type": "array",
+        "description": "管理员用户 ID（可绕过指令白名单）",
+        "items": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "commands": {
+        "type": "object",
+        "description": "指令白名单控制（启用后仅允许 allowlist 内的 / 指令）",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "是否启用指令白名单（默认关闭，保持兼容）"
+          },
+          "allowlist": {
+            "type": "array",
+            "description": "允许的指令列表（如 /status、/new）",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          },
+          "rejectMessage": {
+            "type": "string",
+            "description": "命中未授权指令时返回给用户的提示文本"
+          }
+        }
+      },
+      "groupChat": {
+        "type": "object",
+        "description": "群聊触发策略",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true,
+            "description": "是否启用群聊消息处理"
+          },
+          "requireMention": {
+            "type": "boolean",
+            "default": false,
+            "description": "群聊是否必须包含 @ 提及才触发"
+          },
+          "mentionPatterns": {
+            "type": "array",
+            "description": "提及匹配关键字（默认 ['@']）",
+            "items": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        }
+      },
+      "debounce": {
+        "type": "object",
+        "description": "文本消息防抖合并",
+        "additionalProperties": false,
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "是否启用文本防抖（默认关闭，保持兼容）"
+          },
+          "windowMs": {
+            "type": "integer",
+            "minimum": 100,
+            "maximum": 10000,
+            "default": 1200,
+            "description": "防抖窗口（毫秒）"
+          },
+          "maxBatch": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 50,
+            "default": 6,
+            "description": "单次最多合并消息条数"
+          }
+        }
       },
       "voiceTranscription": {
         "type": "object",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openclaw-wechat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openclaw-wechat",
-      "version": "0.4.4",
+      "version": "0.4.5",
       "license": "MIT",
       "dependencies": {
         "fast-xml-parser": "^5.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openclaw-wechat",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "private": true,
   "type": "module",
   "description": "WeCom (企业微信) channel plugin for OpenClaw (自建应用回调 + 发送 API).",

--- a/src/core.js
+++ b/src/core.js
@@ -32,6 +32,14 @@ const AUDIO_CONTENT_TYPE_TO_EXTENSION = Object.freeze({
   "audio/x-wav": ".wav",
   "audio/x-flac": ".flac",
 });
+const DEFAULT_COMMAND_ALLOWLIST = Object.freeze([
+  "/help",
+  "/status",
+  "/clear",
+  "/reset",
+  "/new",
+  "/compact",
+]);
 
 const inboundMessageDedupe = new Map();
 
@@ -209,6 +217,12 @@ function asPositiveInteger(value, fallback) {
   return Math.floor(n);
 }
 
+function asBoundedPositiveInteger(value, fallback, minimum, maximum) {
+  const n = asPositiveInteger(value, fallback);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(minimum, Math.min(maximum, n));
+}
+
 function parseBooleanLike(value, fallback) {
   if (typeof value === "boolean") return value;
   if (typeof value !== "string") return fallback;
@@ -217,6 +231,197 @@ function parseBooleanLike(value, fallback) {
   if (TRUE_LIKE_VALUES.has(normalized)) return true;
   if (FALSE_LIKE_VALUES.has(normalized)) return false;
   return fallback;
+}
+
+function parseStringList(...values) {
+  const out = [];
+  for (const value of values) {
+    if (Array.isArray(value)) {
+      for (const item of value) {
+        const trimmed = String(item ?? "").trim();
+        if (trimmed) out.push(trimmed);
+      }
+      continue;
+    }
+    if (typeof value === "string") {
+      for (const part of value.split(/[,\n]/)) {
+        const trimmed = part.trim();
+        if (trimmed) out.push(trimmed);
+      }
+    }
+  }
+  return out;
+}
+
+function uniqueLowerCaseList(values) {
+  const deduped = new Set();
+  for (const raw of values) {
+    const normalized = String(raw ?? "").trim().toLowerCase();
+    if (normalized) deduped.add(normalized);
+  }
+  return Array.from(deduped);
+}
+
+function normalizeCommandToken(value) {
+  const normalized = String(value ?? "").trim().toLowerCase();
+  if (!normalized) return "";
+  return normalized.startsWith("/") ? normalized : `/${normalized}`;
+}
+
+function uniqueCommandList(values) {
+  const deduped = new Set();
+  for (const value of values) {
+    const normalized = normalizeCommandToken(value);
+    if (normalized) deduped.add(normalized);
+  }
+  return Array.from(deduped);
+}
+
+export function extractLeadingSlashCommand(text) {
+  const normalized = String(text ?? "").trim();
+  if (!normalized.startsWith("/")) return "";
+  const command = normalized.split(/\s+/)[0]?.trim().toLowerCase() ?? "";
+  return normalizeCommandToken(command);
+}
+
+export function resolveWecomCommandPolicyConfig({
+  channelConfig = {},
+  envVars = {},
+  processEnv = process.env,
+} = {}) {
+  const commandConfig =
+    channelConfig?.commands && typeof channelConfig.commands === "object" ? channelConfig.commands : {};
+  const enabled = parseBooleanLike(
+    commandConfig.enabled,
+    parseBooleanLike(envVars?.WECOM_COMMANDS_ENABLED, parseBooleanLike(processEnv?.WECOM_COMMANDS_ENABLED, false)),
+  );
+  const configuredAllowlist = uniqueCommandList(
+    parseStringList(
+      commandConfig.allowlist,
+      envVars?.WECOM_COMMANDS_ALLOWLIST,
+      processEnv?.WECOM_COMMANDS_ALLOWLIST,
+    ),
+  );
+  const allowlist = configuredAllowlist.length > 0 ? configuredAllowlist : Array.from(DEFAULT_COMMAND_ALLOWLIST);
+  const adminUsers = uniqueLowerCaseList(
+    parseStringList(channelConfig?.adminUsers, envVars?.WECOM_ADMIN_USERS, processEnv?.WECOM_ADMIN_USERS),
+  );
+  const rejectMessage = pickFirstNonEmptyString(
+    commandConfig.rejectMessage,
+    envVars?.WECOM_COMMANDS_REJECT_MESSAGE,
+    processEnv?.WECOM_COMMANDS_REJECT_MESSAGE,
+    "该指令未开放，请联系管理员。",
+  );
+
+  return {
+    enabled,
+    allowlist,
+    adminUsers,
+    rejectMessage,
+  };
+}
+
+export function resolveWecomGroupChatConfig({
+  channelConfig = {},
+  envVars = {},
+  processEnv = process.env,
+} = {}) {
+  const groupConfig =
+    channelConfig?.groupChat && typeof channelConfig.groupChat === "object" ? channelConfig.groupChat : {};
+  const enabled = parseBooleanLike(
+    groupConfig.enabled,
+    parseBooleanLike(envVars?.WECOM_GROUP_CHAT_ENABLED, parseBooleanLike(processEnv?.WECOM_GROUP_CHAT_ENABLED, true)),
+  );
+  const requireMention = parseBooleanLike(
+    groupConfig.requireMention,
+    parseBooleanLike(
+      envVars?.WECOM_GROUP_CHAT_REQUIRE_MENTION,
+      parseBooleanLike(processEnv?.WECOM_GROUP_CHAT_REQUIRE_MENTION, false),
+    ),
+  );
+  const mentionPatterns = parseStringList(
+    groupConfig.mentionPatterns,
+    envVars?.WECOM_GROUP_CHAT_MENTION_PATTERNS,
+    processEnv?.WECOM_GROUP_CHAT_MENTION_PATTERNS,
+    "@",
+  );
+  const dedupedPatterns = [];
+  const seen = new Set();
+  for (const pattern of mentionPatterns) {
+    const token = String(pattern ?? "").trim();
+    if (!token || seen.has(token)) continue;
+    seen.add(token);
+    dedupedPatterns.push(token);
+  }
+
+  return {
+    enabled,
+    requireMention,
+    mentionPatterns: dedupedPatterns.length > 0 ? dedupedPatterns : ["@"],
+  };
+}
+
+export function shouldTriggerWecomGroupResponse(content, groupChatConfig) {
+  if (groupChatConfig?.enabled === false) return false;
+  if (groupChatConfig?.requireMention !== true) return true;
+  const text = String(content ?? "");
+  if (!text.trim()) return false;
+  const patterns =
+    Array.isArray(groupChatConfig?.mentionPatterns) && groupChatConfig.mentionPatterns.length > 0
+      ? groupChatConfig.mentionPatterns
+      : ["@"];
+  return patterns.some((pattern) => text.includes(pattern));
+}
+
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+export function stripWecomGroupMentions(content, mentionPatterns = ["@"]) {
+  let text = String(content ?? "");
+  const patterns = Array.isArray(mentionPatterns) && mentionPatterns.length > 0 ? mentionPatterns : ["@"];
+  for (const rawPattern of patterns) {
+    const pattern = String(rawPattern ?? "").trim();
+    if (!pattern) continue;
+    if (pattern === "@") {
+      // Remove "@name" mentions at start or after whitespace, avoid matching email addresses.
+      text = text.replace(/(^|\s)@[^\s@]+/g, "$1");
+      continue;
+    }
+    const escaped = escapeRegExp(pattern);
+    text = text.replace(new RegExp(escaped, "g"), " ");
+  }
+  return text.replace(/\s{2,}/g, " ").trim();
+}
+
+export function resolveWecomDebounceConfig({
+  channelConfig = {},
+  envVars = {},
+  processEnv = process.env,
+} = {}) {
+  const debounceConfig =
+    channelConfig?.debounce && typeof channelConfig.debounce === "object" ? channelConfig.debounce : {};
+  const enabled = parseBooleanLike(
+    debounceConfig.enabled,
+    parseBooleanLike(envVars?.WECOM_DEBOUNCE_ENABLED, parseBooleanLike(processEnv?.WECOM_DEBOUNCE_ENABLED, false)),
+  );
+  const windowMs = asBoundedPositiveInteger(
+    debounceConfig.windowMs ?? envVars?.WECOM_DEBOUNCE_WINDOW_MS ?? processEnv?.WECOM_DEBOUNCE_WINDOW_MS,
+    1200,
+    100,
+    10000,
+  );
+  const maxBatch = asBoundedPositiveInteger(
+    debounceConfig.maxBatch ?? envVars?.WECOM_DEBOUNCE_MAX_BATCH ?? processEnv?.WECOM_DEBOUNCE_MAX_BATCH,
+    6,
+    1,
+    50,
+  );
+  return {
+    enabled,
+    windowMs,
+    maxBatch,
+  };
 }
 
 function readVoiceEnv(envVars, processEnv, suffix) {

--- a/src/index.js
+++ b/src/index.js
@@ -17,8 +17,14 @@ import {
   isLocalVoiceInputTypeDirectlySupported,
   normalizeAudioContentType,
   pickAudioFileExtension,
+  extractLeadingSlashCommand,
+  resolveWecomCommandPolicyConfig,
+  resolveWecomDebounceConfig,
+  resolveWecomGroupChatConfig,
   resolveVoiceTranscriptionConfig,
   resolveWecomProxyConfig,
+  shouldTriggerWecomGroupResponse,
+  stripWecomGroupMentions,
   splitWecomText,
   pickAccountBySignature,
 } from "./core.js";
@@ -30,7 +36,7 @@ const xmlParser = new XMLParser({
 
 // 请求体大小限制 (1MB)
 const MAX_REQUEST_BODY_SIZE = 1024 * 1024;
-const PLUGIN_VERSION = "0.4.4";
+const PLUGIN_VERSION = "0.4.5";
 const WECOM_TEMP_DIR_NAME = "openclaw-wechat";
 const WECOM_TEMP_FILE_RETENTION_MS = 30 * 60 * 1000;
 const FFMPEG_PATH_CHECK_CACHE = {
@@ -40,6 +46,7 @@ const FFMPEG_PATH_CHECK_CACHE = {
 const COMMAND_PATH_CHECK_CACHE = new Map();
 const WECOM_PROXY_DISPATCHER_CACHE = new Map();
 const INVALID_PROXY_CACHE = new Set();
+const TEXT_MESSAGE_DEBOUNCE_BUFFERS = new Map();
 
 function readRequestBody(req, maxSize = MAX_REQUEST_BODY_SIZE) {
   return new Promise((resolve, reject) => {
@@ -1288,6 +1295,128 @@ function groupAccountsByWebhookPath(api) {
   return grouped;
 }
 
+function resolveWecomPolicyInputs(api) {
+  const cfg = api?.config ?? gatewayRuntime?.config ?? {};
+  return {
+    channelConfig: cfg?.channels?.wecom ?? {},
+    envVars: cfg?.env?.vars ?? {},
+    processEnv: process.env,
+  };
+}
+
+function resolveWecomCommandPolicy(api) {
+  return resolveWecomCommandPolicyConfig(resolveWecomPolicyInputs(api));
+}
+
+function resolveWecomGroupChatPolicy(api) {
+  return resolveWecomGroupChatConfig(resolveWecomPolicyInputs(api));
+}
+
+function resolveWecomTextDebouncePolicy(api) {
+  return resolveWecomDebounceConfig(resolveWecomPolicyInputs(api));
+}
+
+function buildTextDebounceBufferKey({ accountId, fromUser, chatId, isGroupChat }) {
+  const account = String(accountId ?? "default").trim().toLowerCase() || "default";
+  const user = String(fromUser ?? "").trim().toLowerCase();
+  const group = String(chatId ?? "").trim().toLowerCase();
+  if (isGroupChat) {
+    return `${account}:group:${group || "unknown"}:user:${user || "unknown"}`;
+  }
+  return `${account}:dm:${user || "unknown"}`;
+}
+
+function dispatchTextPayload(api, payload, reason = "direct") {
+  messageProcessLimiter
+    .execute(() => processInboundMessage(payload))
+    .catch((err) => {
+      api.logger.error?.(`wecom: async text processing failed (${reason}): ${err.message}`);
+    });
+}
+
+function flushTextDebounceBuffer(api, debounceKey, reason = "timer") {
+  const buffered = TEXT_MESSAGE_DEBOUNCE_BUFFERS.get(debounceKey);
+  if (!buffered) return;
+
+  TEXT_MESSAGE_DEBOUNCE_BUFFERS.delete(debounceKey);
+  if (buffered.timer) clearTimeout(buffered.timer);
+  const mergedContent = buffered.messages.join("\n").trim();
+  if (!mergedContent) return;
+
+  api.logger.info?.(
+    `wecom: flushing debounced text buffer key=${debounceKey} count=${buffered.messages.length} reason=${reason}`,
+  );
+  dispatchTextPayload(
+    api,
+    {
+      ...buffered.basePayload,
+      msgType: "text",
+      content: mergedContent,
+      msgId: buffered.msgIds[0] ?? buffered.basePayload.msgId ?? "",
+    },
+    `debounce:${reason}`,
+  );
+}
+
+function scheduleTextInboundProcessing(api, basePayload, content) {
+  const text = String(content ?? "");
+  let commandProbeText = text;
+  if (basePayload?.isGroupChat) {
+    const groupPolicy = resolveWecomGroupChatPolicy(api);
+    commandProbeText = stripWecomGroupMentions(commandProbeText, groupPolicy.mentionPatterns);
+  }
+  const command = extractLeadingSlashCommand(commandProbeText);
+  const debounceConfig = resolveWecomTextDebouncePolicy(api);
+  const debounceKey = buildTextDebounceBufferKey(basePayload);
+
+  if (command) {
+    flushTextDebounceBuffer(api, debounceKey, "command-priority");
+    dispatchTextPayload(api, { ...basePayload, content: text, msgType: "text" }, "command");
+    return;
+  }
+
+  if (!debounceConfig.enabled) {
+    dispatchTextPayload(api, { ...basePayload, content: text, msgType: "text" }, "direct");
+    return;
+  }
+
+  const existing = TEXT_MESSAGE_DEBOUNCE_BUFFERS.get(debounceKey);
+  if (!existing) {
+    const timer = setTimeout(() => {
+      flushTextDebounceBuffer(api, debounceKey, "window-expired");
+    }, debounceConfig.windowMs);
+    timer.unref?.();
+
+    TEXT_MESSAGE_DEBOUNCE_BUFFERS.set(debounceKey, {
+      basePayload,
+      messages: [text],
+      msgIds: [basePayload.msgId ?? ""],
+      timer,
+      updatedAt: Date.now(),
+    });
+    api.logger.info?.(
+      `wecom: buffered text message key=${debounceKey} count=1 windowMs=${debounceConfig.windowMs}`,
+    );
+    return;
+  }
+
+  if (existing.timer) clearTimeout(existing.timer);
+  existing.messages.push(text);
+  existing.msgIds.push(basePayload.msgId ?? "");
+  existing.updatedAt = Date.now();
+
+  if (existing.messages.length >= debounceConfig.maxBatch) {
+    flushTextDebounceBuffer(api, debounceKey, "max-batch");
+    return;
+  }
+
+  existing.timer = setTimeout(() => {
+    flushTextDebounceBuffer(api, debounceKey, "window-expired");
+  }, debounceConfig.windowMs);
+  existing.timer.unref?.();
+  TEXT_MESSAGE_DEBOUNCE_BUFFERS.set(debounceKey, existing);
+}
+
 export default function register(api) {
   // 保存 runtime 引用
   gatewayRuntime = api.runtime;
@@ -1453,11 +1582,7 @@ export default function register(api) {
 
           // 异步处理消息，不阻塞响应
           if (msgType === "text" && msgObj?.Content) {
-            messageProcessLimiter.execute(() =>
-              processInboundMessage({ ...basePayload, content: msgObj.Content, msgType: "text" })
-            ).catch((err) => {
-              api.logger.error?.(`wecom: async text processing failed: ${err.message}`);
-            });
+            scheduleTextInboundProcessing(api, basePayload, msgObj.Content);
           } else if (msgType === "image" && msgObj?.MediaId) {
             messageProcessLimiter.execute(() =>
               processInboundMessage({
@@ -1580,10 +1705,24 @@ async function handleStatusCommand({ api, fromUser, corpId, corpSecret, agentId,
   const config = getWecomConfig(api, accountId);
   const accountIds = listWecomAccountIds(api);
   const voiceConfig = resolveWecomVoiceTranscriptionConfig(api);
+  const commandPolicy = resolveWecomCommandPolicy(api);
+  const groupPolicy = resolveWecomGroupChatPolicy(api);
+  const debouncePolicy = resolveWecomTextDebouncePolicy(api);
   const proxyEnabled = Boolean(config?.outboundProxy);
   const voiceStatusLine = voiceConfig.enabled
     ? `✅ 语音消息转写（本地 ${voiceConfig.provider}，模型: ${voiceConfig.modelPath || voiceConfig.model}）`
     : "⚠️ 语音消息转写回退未启用（仅使用企业微信 Recognition）";
+  const commandPolicyLine = commandPolicy.enabled
+    ? `✅ 指令白名单已启用（${commandPolicy.allowlist.length} 条，管理员 ${commandPolicy.adminUsers.length} 人）`
+    : "ℹ️ 指令白名单未启用";
+  const groupPolicyLine = groupPolicy.enabled
+    ? groupPolicy.requireMention
+      ? "✅ 群聊触发：仅 @ 命中后处理"
+      : "✅ 群聊触发：无需 @（全部处理）"
+    : "⚠️ 群聊处理未启用";
+  const debouncePolicyLine = debouncePolicy.enabled
+    ? `✅ 文本防抖合并已启用（${debouncePolicy.windowMs}ms / 最多 ${debouncePolicy.maxBatch} 条）`
+    : "ℹ️ 文本防抖合并未启用";
 
   const statusText = `📊 系统状态
 
@@ -1601,6 +1740,9 @@ async function handleStatusCommand({ api, fromUser, corpId, corpSecret, agentId,
 ✅ Markdown 转换
 ✅ API 限流
 ✅ 多账户支持
+${commandPolicyLine}
+${groupPolicyLine}
+${debouncePolicyLine}
 ${proxyEnabled ? "✅ WeCom 出站代理已启用" : "ℹ️ WeCom 出站代理未启用"}
 ${voiceStatusLine}`;
 
@@ -1661,28 +1803,69 @@ async function processInboundMessage({
     let commandBody = originalContent;
     api.logger.info?.(`wecom: processing ${msgType} message for session ${sessionId}${isGroupChat ? " (group)" : ""}`);
 
+    // 群聊触发策略（仅对文本消息）
+    if (msgType === "text" && isGroupChat) {
+      const groupChatPolicy = resolveWecomGroupChatPolicy(api);
+      if (!groupChatPolicy.enabled) {
+        api.logger.info?.(`wecom: group chat processing disabled, skipped chatId=${chatId || "unknown"}`);
+        return;
+      }
+      if (!shouldTriggerWecomGroupResponse(commandBody, groupChatPolicy)) {
+        api.logger.info?.(
+          `wecom: group message skipped by trigger policy chatId=${chatId || "unknown"} requireMention=${groupChatPolicy.requireMention}`,
+        );
+        return;
+      }
+      commandBody = stripWecomGroupMentions(commandBody, groupChatPolicy.mentionPatterns);
+      if (!commandBody.trim()) {
+        api.logger.info?.(`wecom: group message became empty after mention strip chatId=${chatId || "unknown"}`);
+        return;
+      }
+    }
+
     // 命令检测（仅对文本消息）
-    if (msgType === "text" && commandBody.startsWith("/")) {
-      const commandKey = commandBody.split(/\s+/)[0].toLowerCase();
+    if (msgType === "text") {
+      let commandKey = extractLeadingSlashCommand(commandBody);
       if (commandKey === "/clear") {
         api.logger.info?.("wecom: translating /clear to native /reset command");
-        commandBody = "/reset";
+        commandBody = commandBody.replace(/^\/clear\b/i, "/reset");
+        commandKey = "/reset";
       }
-      const handler = COMMANDS[commandKey];
-      if (handler) {
-        api.logger.info?.(`wecom: handling command ${commandKey}`);
-        await handler({
-          api,
-          fromUser,
-          corpId,
-          corpSecret,
-          agentId,
-          accountId: config.accountId || "default",
-          proxyUrl,
-          chatId,
-          isGroupChat,
-        });
-        return; // 命令已处理，不再调用 AI
+      if (commandKey) {
+        const commandPolicy = resolveWecomCommandPolicy(api);
+        const isAdminUser = commandPolicy.adminUsers.includes(String(fromUser ?? "").trim().toLowerCase());
+        const commandAllowed =
+          commandPolicy.allowlist.includes(commandKey) ||
+          (commandKey === "/reset" && commandPolicy.allowlist.includes("/clear"));
+        if (commandPolicy.enabled && !isAdminUser && !commandAllowed) {
+          api.logger.info?.(`wecom: command blocked by allowlist user=${fromUser} command=${commandKey}`);
+          await sendWecomText({
+            corpId,
+            corpSecret,
+            agentId,
+            toUser: fromUser,
+            text: commandPolicy.rejectMessage,
+            logger: api.logger,
+            proxyUrl,
+          });
+          return;
+        }
+        const handler = COMMANDS[commandKey];
+        if (handler) {
+          api.logger.info?.(`wecom: handling command ${commandKey}`);
+          await handler({
+            api,
+            fromUser,
+            corpId,
+            corpSecret,
+            agentId,
+            accountId: config.accountId || "default",
+            proxyUrl,
+            chatId,
+            isGroupChat,
+          });
+          return; // 命令已处理，不再调用 AI
+        }
       }
     }
 

--- a/tests/wecom-core.test.mjs
+++ b/tests/wecom-core.test.mjs
@@ -149,3 +149,60 @@ test("resolveWecomProxyConfig supports account-specific env fallback", () => {
   });
   assert.equal(proxy, "http://sales-proxy:8080");
 });
+
+test("extractLeadingSlashCommand normalizes command key", () => {
+  assert.equal(core.extractLeadingSlashCommand("/STATUS"), "/status");
+  assert.equal(core.extractLeadingSlashCommand(" /new  test"), "/new");
+  assert.equal(core.extractLeadingSlashCommand("hello"), "");
+});
+
+test("resolveWecomCommandPolicyConfig reads admin and allowlist", () => {
+  const policy = core.resolveWecomCommandPolicyConfig({
+    channelConfig: {
+      adminUsers: ["Alice", "Bob"],
+      commands: {
+        enabled: true,
+        allowlist: ["status", "/new", " /compact "],
+      },
+    },
+    envVars: {},
+    processEnv: {},
+  });
+  assert.equal(policy.enabled, true);
+  assert.deepEqual(policy.allowlist.sort(), ["/compact", "/new", "/status"].sort());
+  assert.deepEqual(policy.adminUsers.sort(), ["alice", "bob"]);
+});
+
+test("group mention helpers trigger and strip correctly", () => {
+  const groupCfg = core.resolveWecomGroupChatConfig({
+    channelConfig: {
+      groupChat: {
+        enabled: true,
+        requireMention: true,
+        mentionPatterns: ["@", "@AI助手"],
+      },
+    },
+    envVars: {},
+    processEnv: {},
+  });
+  assert.equal(core.shouldTriggerWecomGroupResponse("@AI助手 /status", groupCfg), true);
+  assert.equal(core.shouldTriggerWecomGroupResponse("普通文本", groupCfg), false);
+  assert.equal(core.stripWecomGroupMentions("@AI助手 /status", groupCfg.mentionPatterns), "/status");
+});
+
+test("resolveWecomDebounceConfig applies bounds and defaults", () => {
+  const debounce = core.resolveWecomDebounceConfig({
+    channelConfig: {
+      debounce: {
+        enabled: true,
+        windowMs: 20,
+        maxBatch: 99,
+      },
+    },
+    envVars: {},
+    processEnv: {},
+  });
+  assert.equal(debounce.enabled, true);
+  assert.equal(debounce.windowMs, 100);
+  assert.equal(debounce.maxBatch, 50);
+});


### PR DESCRIPTION
## 迭代背景
对比 `sunnoy/openclaw-plugin-wecom` 后，选择先迁移对当前架构最稳妥的三类能力：
- 指令白名单 + 管理员绕过
- 群聊触发策略（可配置 requireMention）
- 文本防抖合并（窗口期多条文本合并投递）

本 PR 不引入 bot-mode/动态 agent 路由等高侵入改造，优先保证兼容和可控上线。

## 主要改动
### 1) 配置与 schema
- `openclaw.plugin.json`
  - 新增 `adminUsers`
  - 新增 `commands.enabled/allowlist/rejectMessage`
  - 新增 `groupChat.enabled/requireMention/mentionPatterns`
  - 新增 `debounce.enabled/windowMs/maxBatch`
- 版本同步到 `0.4.5`

### 2) 核心解析能力
- `src/core.js`
  - 新增 `extractLeadingSlashCommand`
  - 新增 `resolveWecomCommandPolicyConfig`
  - 新增 `resolveWecomGroupChatConfig`
  - 新增 `resolveWecomDebounceConfig`
  - 新增 `shouldTriggerWecomGroupResponse`
  - 新增 `stripWecomGroupMentions`
- 修复：`allowlist` 在显式配置时不再与默认列表并集，支持真正“收窄”白名单。

### 3) 入站处理链路接入
- `src/index.js`
  - 文本消息接入 `scheduleTextInboundProcessing`（防抖+命令优先）
  - `processInboundMessage` 接入：
    - 群聊触发门控（enabled/requireMention）
    - mention 剥离后再识别命令
    - 命令白名单拦截 + admin bypass
  - `/status` 新增命令策略/群聊策略/防抖策略状态展示

### 4) 测试与文档
- `tests/wecom-core.test.mjs` 增加策略与解析相关测试
- `README.md` 增补配置示例与环境变量说明
- `.env.example` 增补策略变量
- `CHANGELOG.md` 新增 `0.4.5` 条目

## 验证
```bash
npm test
```
结果：13 passed, 0 failed。

